### PR TITLE
Fix deprecation warning about appending module_ to the parent_name call!

### DIFF
--- a/app/views/layouts/administrate/application.html.erb
+++ b/app/views/layouts/administrate/application.html.erb
@@ -19,7 +19,7 @@ By default, it renders:
   <meta name="ROBOTS" content="NOODP">
   <meta name="viewport" content="initial-scale=1">
   <title>
-    <%= content_for(:title) %> - <%= Rails.application.class.parent_name.titlecase %>
+    <%= content_for(:title) %> - <%= Rails.application.class.module_parent_name.titlecase %>
   </title>
   <%= render "stylesheet" %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
This is a simple change on the application template to fix the deprecation warning below:
#### DEPRECATION WARNING: `Module#parent_name` has been renamed to `module_parent_name`. `parent_name` is deprecated a$ d will be removed in Rails 6.1.