### PR TITLE
fix: assets precompiler broke compatibility with external engines

### DIFF
--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -23,10 +23,8 @@ module Administrate
     @@stylesheets = []
 
     initializer "administrate.assets.precompile" do |app|
-      app.config.assets.precompile += [
-        "administrate/application.js",
-        "administrate/application.css",
-      ]
+      app.config.assets.precompile += @@javascripts.map { |f| "#{f}.js" }
+      app.config.assets.precompile += @@stylesheets.map { |f| "#{f}.css" }
     end
 
     def self.add_javascript(script)

--- a/lib/administrate/field/belongs_to.rb
+++ b/lib/administrate/field/belongs_to.rb
@@ -34,7 +34,15 @@ module Administrate
       private
 
       def candidate_resources
-        scope = options[:scope] ? options[:scope].call : associated_class.all
+        scope =
+          case options[:scope]&.arity
+          when nil
+            associated_class.all
+          when 0
+            options[:scope].call
+          else
+            options[:scope].call(self)
+          end
 
         order = options.delete(:order)
         order ? scope.reorder(order) : scope


### PR DESCRIPTION
Fixes the following issue:

### S2R:

1. Add a administrate plug-in that requires additional assets, such as `administrate-field-nested_has_many`
2. Require its javascript using `javascript_include_tag "administrate-field-nested_has_many/application"`

### Expected:

It works! 🎉 

### Observed:

Exception thrown: `Sprockets::Rails::Helper::AssetNotPrecompiled`

### Notes: 

The assets used by `add_javascript` and `add_stylesheet` (other than administrate's own assets) are yielded, but not precompiled, which results in the error above.

There might be a nicer way to do this, but my knowledge of Rails / Sprockets internals is limited.