### PR TITLE
Added required attribute to form fields

### DIFF
--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -22,5 +22,6 @@ that displays all possible records to associate with.
 <div class="field-unit__field">
   <%= f.select(field.permitted_attribute,
                options_for_select(field.associated_resource_options, field.selected_option),
-               include_blank: field.include_blank_option) %>
+               include_blank: field.include_blank_option,
+               required: field.required?) %>
 </div>

--- a/app/views/fields/date/_form.html.erb
+++ b/app/views/fields/date/_form.html.erb
@@ -20,5 +20,5 @@ By default, the input is a text field that is augmented with [DateTimePicker].
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_field field.attribute, data: { type: 'date' }  %>
+  <%= f.text_field field.attribute, data: { type: 'date' }, required: field.required? %>
 </div>

--- a/app/views/fields/date_time/_form.html.erb
+++ b/app/views/fields/date_time/_form.html.erb
@@ -20,5 +20,5 @@ By default, the input is a text field that is augmented with [DateTimePicker].
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_field field.attribute, data: { type: 'datetime' }  %>
+  <%= f.text_field field.attribute, data: { type: 'datetime' }, required: field.required? %>
 </div>

--- a/app/views/fields/email/_form.html.erb
+++ b/app/views/fields/email/_form.html.erb
@@ -19,5 +19,5 @@ By default, the input is a text box.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.email_field field.attribute %>
+  <%= f.email_field field.attribute, required: field.required?  %>
 </div>

--- a/app/views/fields/number/_form.html.erb
+++ b/app/views/fields/number/_form.html.erb
@@ -19,5 +19,5 @@ By default, the input is a text field.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.number_field field.attribute, step: "any" %>
+  <%= f.number_field field.attribute, step: "any", required: field.required?  %>
 </div>

--- a/app/views/fields/password/_form.html.erb
+++ b/app/views/fields/password/_form.html.erb
@@ -19,5 +19,5 @@ By default, the input is a password field.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.password_field field.attribute, value: field.data %>
+  <%= f.password_field field.attribute, value: field.data, required: field.required?  %>
 </div>

--- a/app/views/fields/rich_text/_form.html.erb
+++ b/app/views/fields/rich_text/_form.html.erb
@@ -18,5 +18,5 @@ This partial renders a textarea element for a text attribute.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.rich_text_area field.attribute, data: { controller: "mentions", target: "mentions.field" } %>
+  <%= f.rich_text_area field.attribute, data: { controller: "mentions", target: "mentions.field" }, required: field.required? %>
 </div>

--- a/app/views/fields/select/_form.html.erb
+++ b/app/views/fields/select/_form.html.erb
@@ -27,7 +27,8 @@ to be displayed on a resource's edit form page.
         :last,
         :first,
         field.data,
-      )
+      ),
+      required: field.required?
     ) %>
   <% else %>
     <%= f.select(
@@ -37,7 +38,8 @@ to be displayed on a resource's edit form page.
         :to_s,
         :to_s,
         field.data,
-      )
+      ),
+      required: field.required?
     ) %>
   <% end %>
 </div>

--- a/app/views/fields/string/_form.html.erb
+++ b/app/views/fields/string/_form.html.erb
@@ -19,5 +19,5 @@ By default, the input is a text field.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_field field.attribute %>
+  <%= f.text_field field.attribute, required: field.required?  %>
 </div>

--- a/app/views/fields/text/_form.html.erb
+++ b/app/views/fields/text/_form.html.erb
@@ -18,5 +18,5 @@ This partial renders a textarea element for a text attribute.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_area field.attribute %>
+  <%= f.text_area field.attribute, required: field.required? %>
 </div>

--- a/app/views/fields/time/_form.html.erb
+++ b/app/views/fields/time/_form.html.erb
@@ -19,5 +19,5 @@ By default, the input is a text field that is augmented with [DateTimePicker].
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.text_field field.attribute, data: { type: 'time' }, value: field.data&.strftime("%H:%M:%S") %>
+  <%= f.text_field field.attribute, data: { type: 'time' }, value: field.data&.strftime("%H:%M:%S"), required: field.required? %>
 </div>

--- a/app/views/fields/url/_form.html.erb
+++ b/app/views/fields/url/_form.html.erb
@@ -19,5 +19,5 @@ By default, the input is a text box.
   <%= f.label field.attribute %>
 </div>
 <div class="field-unit__field">
-  <%= f.url_field field.attribute %>
+  <%= f.url_field field.attribute, required: field.required? %>
 </div>

--- a/spec/administrate/views/fields/string/_form_spec.rb
+++ b/spec/administrate/views/fields/string/_form_spec.rb
@@ -1,25 +1,22 @@
 require "rails_helper"
-require "administrate/field/select"
+require "administrate/field/string"
 
 describe "fields/select/_form", type: :view do
-  it "displays the selected option" do
+  it "sets required attribute if required" do
     customer = build(:customer)
-    select = instance_double(
-      "Administrate::Field::Select",
-      attribute: :email_subscriber,
-      data: false,
-      selectable_options: [true, false, nil],
-      required?: false
+    string = instance_double(
+      "Administrate::Field::String",
+      attribute: :name,
+      required?: true
     )
 
     render(
-      partial: "fields/select/form",
-      locals: { field: select, f: form_builder(customer) },
+      partial: "fields/string/form",
+      locals: { field: string, f: form_builder(customer) },
     )
 
     expect(rendered).to have_css(
-      %{select[name="customer[email_subscriber]"]
-        option[value="false"][selected="selected"]},
+      %{input[type=text][required=required]}
     )
   end
 

--- a/spec/administrate/views/fields/url/_form_spec.rb
+++ b/spec/administrate/views/fields/url/_form_spec.rb
@@ -8,6 +8,7 @@ describe "fields/url/_form", type: :view do
       "Administrate::Field::Url",
       attribute: :image_url,
       data: nil,
+      required: false
     )
 
     render(


### PR DESCRIPTION
Set the `required` attribute on form inputs if the corresponding model attribute is not-optional.